### PR TITLE
Add history and updates composables

### DIFF
--- a/presentation/src/main/kotlin/core/components/MangaListItem.kt
+++ b/presentation/src/main/kotlin/core/components/MangaListItem.kt
@@ -1,0 +1,86 @@
+package tachiyomi.ui.core.components
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import com.google.accompanist.coil.rememberCoilPainter
+import tachiyomi.ui.core.coil.MangaCover
+
+@Composable
+fun MangaListItem(
+  modifier: Modifier = Modifier,
+  content: @Composable RowScope.() -> Unit
+) {
+  Row(
+    modifier = modifier,
+    verticalAlignment = Alignment.CenterVertically
+  ) {
+    content()
+  }
+}
+
+@Composable
+fun MangaListItemImage(
+  modifier: Modifier = Modifier,
+  mangaCover: MangaCover
+) {
+  Image(
+    painter = rememberCoilPainter(mangaCover),
+    contentDescription = null,
+    modifier = modifier,
+    contentScale = ContentScale.Crop
+  )
+}
+
+@Composable
+fun MangaListItemColumn(
+  modifier: Modifier = Modifier,
+  content: @Composable ColumnScope.() -> Unit
+) {
+  Column(
+    modifier = modifier
+  ) {
+    content()
+  }
+}
+
+@Composable
+fun MangaListItemTitle(
+  modifier: Modifier = Modifier,
+  text: String,
+  maxLines: Int = 1,
+  fontWeight: FontWeight = FontWeight.Normal
+) {
+  Text(
+    modifier = modifier,
+    text = text,
+    maxLines = maxLines,
+    overflow = TextOverflow.Ellipsis,
+    style = MaterialTheme.typography.body2,
+    fontWeight = fontWeight
+  )
+}
+
+@Composable
+fun MangaListItemSubtitle(
+  modifier: Modifier = Modifier,
+  text: String
+) {
+  Text(
+    modifier = modifier,
+    text = text,
+    maxLines = 1,
+    overflow = TextOverflow.Ellipsis,
+    style = MaterialTheme.typography.caption
+  )
+}

--- a/presentation/src/main/kotlin/history/HistoryScreen.kt
+++ b/presentation/src/main/kotlin/history/HistoryScreen.kt
@@ -8,12 +8,35 @@
 
 package tachiyomi.ui.history
 
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.outlined.Delete
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
+import tachiyomi.domain.manga.model.Manga
 import tachiyomi.ui.R
+import tachiyomi.ui.core.coil.rememberMangaCover
+import tachiyomi.ui.core.components.MangaListItem
+import tachiyomi.ui.core.components.MangaListItemColumn
+import tachiyomi.ui.core.components.MangaListItemImage
+import tachiyomi.ui.core.components.MangaListItemSubtitle
+import tachiyomi.ui.core.components.MangaListItemTitle
 import tachiyomi.ui.core.components.Toolbar
 
 @Composable
@@ -23,5 +46,50 @@ fun HistoryScreen(navController: NavController) {
       Toolbar(title = { Text(stringResource(R.string.history_label)) })
     }
   ) {
+  }
+}
+
+@Composable
+fun HistoryItem(
+  manga: Manga,
+  onClickItem: (Manga) -> Unit = { /* TODO */ },
+  onClickDelete: (Manga) -> Unit = { /* TODO */ },
+  onClickPlay: (Manga) -> Unit = { /* TODO */ }
+) {
+  MangaListItem(
+    modifier = Modifier
+      .clickable { onClickItem(manga) }
+      .height(80.dp)
+      .fillMaxWidth()
+      .padding(end = 4.dp),
+  ) {
+    MangaListItemImage(
+      modifier = Modifier
+        .fillMaxHeight()
+        .aspectRatio(3f / 4f)
+        .padding(start = 16.dp, top = 8.dp, bottom = 8.dp)
+        .clip(MaterialTheme.shapes.medium),
+      mangaCover = rememberMangaCover(manga)
+    )
+    MangaListItemColumn(
+      modifier = Modifier
+        .weight(1f)
+        .padding(start = 16.dp, end = 8.dp)
+    ) {
+      MangaListItemTitle(
+        text = manga.title,
+        maxLines = 2,
+        fontWeight = FontWeight.SemiBold
+      )
+      MangaListItemSubtitle(
+        text = "Ch. 69 - 10:59" // TODO
+      )
+    }
+    IconButton(onClick = { onClickDelete(manga) }) {
+      Icon(imageVector = Icons.Outlined.Delete, contentDescription = "")
+    }
+    IconButton(onClick = { onClickPlay(manga) }) {
+      Icon(imageVector = Icons.Filled.PlayArrow, contentDescription = "")
+    }
   }
 }

--- a/presentation/src/main/kotlin/library/LibraryMangaList.kt
+++ b/presentation/src/main/kotlin/library/LibraryMangaList.kt
@@ -8,10 +8,8 @@
 
 package tachiyomi.ui.library
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.combinedClickable
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.requiredHeight
@@ -19,17 +17,16 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
-import com.google.accompanist.coil.rememberCoilPainter
 import tachiyomi.domain.library.model.LibraryManga
 import tachiyomi.ui.core.coil.rememberMangaCover
+import tachiyomi.ui.core.components.MangaListItem
+import tachiyomi.ui.core.components.MangaListItemImage
+import tachiyomi.ui.core.components.MangaListItemTitle
 
 @Composable
 fun LibraryMangaList(
@@ -61,28 +58,24 @@ private fun LibraryMangaListItem(
   onClick: () -> Unit,
   onLongClick: () -> Unit
 ) {
-  Row(
+  MangaListItem(
     modifier = Modifier
       .combinedClickable(onClick = onClick, onLongClick = onLongClick)
       .selectionBackground(isSelected)
       .requiredHeight(56.dp)
       .padding(horizontal = 16.dp),
-    verticalAlignment = Alignment.CenterVertically
   ) {
-    Image(
-      painter = rememberCoilPainter(rememberMangaCover(manga)),
-      contentDescription = null,
+    MangaListItemImage(
       modifier = Modifier
         .size(40.dp)
         .clip(MaterialTheme.shapes.medium),
-      contentScale = ContentScale.Crop
+      mangaCover = rememberMangaCover(manga)
     )
-    Text(
-      text = manga.title,
+    MangaListItemTitle(
       modifier = Modifier
         .weight(1f)
         .padding(horizontal = 16.dp),
-      style = MaterialTheme.typography.body2
+      text = manga.title,
     )
     LibraryMangaBadges(unread, downloaded)
   }

--- a/presentation/src/main/kotlin/updates/UpdatesScreen.kt
+++ b/presentation/src/main/kotlin/updates/UpdatesScreen.kt
@@ -8,12 +8,34 @@
 
 package tachiyomi.ui.updates
 
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Download
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
+import tachiyomi.domain.manga.model.Manga
 import tachiyomi.ui.R
+import tachiyomi.ui.core.coil.rememberMangaCover
+import tachiyomi.ui.core.components.MangaListItem
+import tachiyomi.ui.core.components.MangaListItemColumn
+import tachiyomi.ui.core.components.MangaListItemImage
+import tachiyomi.ui.core.components.MangaListItemSubtitle
+import tachiyomi.ui.core.components.MangaListItemTitle
 import tachiyomi.ui.core.components.Toolbar
 
 @Composable
@@ -23,5 +45,46 @@ fun UpdatesScreen(navController: NavController) {
       Toolbar(title = { Text(stringResource(R.string.updates_label)) })
     }
   ) {
+  }
+}
+
+@Composable
+fun UpdatesItem(
+  manga: Manga,
+  onClickItem: (Manga) -> Unit = { /* TODO */ },
+  onClickDownload: (Manga) -> Unit = { /* TODO */}
+) {
+  MangaListItem(
+    modifier = Modifier
+      .clickable { onClickItem(manga) }
+      .height(56.dp)
+      .fillMaxWidth()
+      .padding(end = 4.dp),
+  ) {
+    MangaListItemImage(
+      modifier = Modifier
+        .fillMaxHeight()
+        .aspectRatio(1f)
+        .padding(start = 16.dp, top = 8.dp, bottom = 8.dp)
+        .clip(MaterialTheme.shapes.medium),
+      mangaCover = rememberMangaCover(manga)
+    )
+    MangaListItemColumn(
+      modifier = Modifier
+        .weight(1f)
+        .padding(start = 16.dp)
+    ) {
+      MangaListItemTitle(
+        text = manga.title,
+        fontWeight = FontWeight.SemiBold
+      )
+      MangaListItemSubtitle(
+        text = "Chapter 69" // TODO
+      )
+    }
+    // TODO Add state for when downloading
+    IconButton(onClick = { onClickDownload(manga) }) {
+      Icon(imageVector = Icons.Outlined.Download, contentDescription = "")
+    }
   }
 }


### PR DESCRIPTION
This adds composable list items for history and updates screens.

I did change the library list item a tiny bit because it shares some resembles to the history/update item

| Library List | Updates | History |
|---|---|---|
| ![Screenshot_1621088446](https://user-images.githubusercontent.com/6576096/118374403-3570dc00-b5bc-11eb-91ce-49654b37d01f.png) | ![Screenshot_1621104658](https://user-images.githubusercontent.com/6576096/118375018-4cfd9400-b5bf-11eb-9d1a-1cd5f32fda0b.png) | ![Screenshot_1621104660](https://user-images.githubusercontent.com/6576096/118375024-525ade80-b5bf-11eb-9040-b4919d6c5608.png) |




